### PR TITLE
AIX: process_substition: unlink temporary files immediately after opening

### DIFF
--- a/subst.c
+++ b/subst.c
@@ -5926,8 +5926,11 @@ process_substitute (string, open_for_read_in_child)
 #if !defined (HAVE_DEV_FD)
   /* Open the named pipe in the child. */
   fd = open (pathname, open_for_read_in_child ? O_RDONLY : O_WRONLY);
+#ifdef _AIX
+  /* Only tested on AIX */
   /* now that the file is open (or not) * unlink it to keep garbage down */
   unlink(pathname);
+#endif
   if (fd < 0)
     {
       /* Two separate strings for ease of translation. */

--- a/subst.c
+++ b/subst.c
@@ -5926,6 +5926,8 @@ process_substitute (string, open_for_read_in_child)
 #if !defined (HAVE_DEV_FD)
   /* Open the named pipe in the child. */
   fd = open (pathname, open_for_read_in_child ? O_RDONLY : O_WRONLY);
+  /* now that the file is open (or not) * unlink it to keep garbage down */
+  unlink(pathname);
   if (fd < 0)
     {
       /* Two separate strings for ease of translation. */


### PR DESCRIPTION
Fixes: #1 

There is a complex process within bash to track fifo entries - but this still does not take care of deleting the fifo aka `p` device files created in /tmp to manage the shell redirect known as *process substitution*.

This patch - limited to AIX atm (only platform tested) takes the historical approach of managing temporary files that are not intended to survive a process - ie.e, open() and then unlink().

This works on POSIX systems, in any case, as files are supposed to remain effective as long as the inode exists. And inodes exist when they are open or when the link-count is greater than zero.